### PR TITLE
updated example to be more idiomatic

### DIFF
--- a/src/app/main.cljs
+++ b/src/app/main.cljs
@@ -24,7 +24,7 @@
 ; connect user actions to updater
 (defn dispatch! [op op-data]
   ; use reset! and it triggers watchers
-  (reset! *store (updater @*store op op-data)))
+  (swap! *store updater op op-data))
 
 ; component definitions
 
@@ -33,14 +33,14 @@
   (dispatch! :inc 1))
 
 ; button component, defined with a macro
-(defcomp comp-button (text)
+(defcomp comp-button [text]
   (div {:style ui/button
         ; event handler
         :on {:click on-click}}
     (<> span text nil)))
 
 ; container component
-(defcomp comp-container (store)
+(defcomp comp-container [store]
   (div {}
     ; insert text
     (<> span (:point store) nil)


### PR DESCRIPTION
It's better to use `swap!` when updating state of the atom instead of `reset!` which is meant to be used when you want to set a new state and discard the old state.

Idiomatically arguments are placed in a vector, while lists are used for callable things such as functions.